### PR TITLE
Create RactorLocalSingleton

### DIFF
--- a/lib/singleton.rb
+++ b/lib/singleton.rb
@@ -156,7 +156,7 @@ module Singleton
 
     def self.extended(c)
       # extending an object with Singleton is a bad idea
-      c.singleton_class.undef_method :extend_object
+      c.singleton_class.send(:undef_method, :extend_object)
     end
 
     def __init__(klass) # :nodoc:

--- a/lib/singleton.rb
+++ b/lib/singleton.rb
@@ -196,10 +196,10 @@ module Singleton
   #  Returns the singleton instance.
 end
 
-module PerRactorSingleton
+module RactorLocalSingleton
   include Singleton::SingletonInstanceMethods
 
-  module PerRactorSingletonClassMethods
+  module RactorLocalSingletonClassMethods
     include Singleton::SingletonClassMethods
     def instance
       set_mutex(Thread::Mutex.new) if Ractor.current[mutex_key].nil?
@@ -214,11 +214,11 @@ module PerRactorSingleton
     private
 
     def instance_key
-      :"__PerRactorSingleton_instance_with_class_id_#{object_id}__"
+      :"__RactorLocalSingleton_instance_with_class_id_#{object_id}__"
     end
 
     def mutex_key
-      :"__PerRactorSingleton_mutex_with_class_id_#{object_id}__"
+      :"__RactorLocalSingleton_mutex_with_class_id_#{object_id}__"
     end
 
     def set_instance(val)
@@ -231,7 +231,7 @@ module PerRactorSingleton
   end
 
   def self.module_with_class_methods
-    PerRactorSingletonClassMethods
+    RactorLocalSingletonClassMethods
   end
 
   extend Singleton::SingletonClassProperties

--- a/lib/singleton.rb
+++ b/lib/singleton.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 # The Singleton module implements the Singleton pattern.
 #
@@ -93,7 +93,6 @@
 #
 module Singleton
   VERSION = "0.2.0"
-  VERSION.freeze
 
   module SingletonInstanceMethods
     # Raises a TypeError to prevent cloning.


### PR DESCRIPTION
Classes that include Singleton cannot be used within Ractors, since the instance can only exist within the main Ractor. By creating RactorLocalSingleton, classes have the option of instead having one instance per Ractor.