### PR TITLE
simplify

### DIFF
--- a/lib/singleton.rb
+++ b/lib/singleton.rb
@@ -112,7 +112,7 @@ module Singleton
   module SingletonClassMethods # :nodoc:
 
     def clone # :nodoc:
-      Singleton.__init__(super)
+      super.include(Singleton)
     end
 
     # By default calls instance(). Override to retain singleton state.
@@ -121,31 +121,18 @@ module Singleton
     end
 
     def instance # :nodoc:
-      return @singleton__instance__ if @singleton__instance__
-      @singleton__mutex__.synchronize {
-        return @singleton__instance__ if @singleton__instance__
-        @singleton__instance__ = new()
-      }
-      @singleton__instance__
+      @singleton__instance__ || @singleton__mutex__.synchronize { @singleton__instance__ ||= new }
     end
 
     private
 
     def inherited(sub_klass)
       super
-      Singleton.__init__(sub_klass)
+      sub_klass.include(Singleton)
     end
   end
 
   class << Singleton # :nodoc:
-    def __init__(klass) # :nodoc:
-      klass.instance_eval {
-        @singleton__instance__ = nil
-        @singleton__mutex__ = Thread::Mutex.new
-      }
-      klass
-    end
-
     private
 
     # extending an object with Singleton is a bad idea
@@ -156,14 +143,19 @@ module Singleton
       unless mod.instance_of?(Class)
         raise TypeError, "Inclusion of the OO-Singleton module in module #{mod}"
       end
+
       super
     end
 
     def included(klass)
       super
+
       klass.private_class_method :new, :allocate
       klass.extend SingletonClassMethods
-      Singleton.__init__(klass)
+      klass.instance_eval {
+        @singleton__instance__ = nil
+        @singleton__mutex__ = Thread::Mutex.new
+      }
     end
   end
 

--- a/test/test_singleton.rb
+++ b/test/test_singleton.rb
@@ -94,11 +94,22 @@ class TestSingleton < Test::Unit::TestCase
     assert_same a, b
   end
 
+  def test_inheritance_creates_separate_singleton
+    a = SingletonTest.instance
+    b = Class.new(SingletonTest).instance
+
+    assert_not_same a, b
+  end
+
   def test_class_level_cloning_preserves_singleton_behavior
     klass = SingletonTest.clone
 
     a = klass.instance
     b = klass.instance
     assert_same a, b
+  end
+
+  def test_class_level_cloning_creates_separate_singleton
+    assert_not_same SingletonTest.instance, SingletonTest.clone.instance
   end
 end


### PR DESCRIPTION
I was trying to understand the `Singleton` code (neat!) and saw a few ways we could simplify.  If we roll `Singleton.__init__` into `included`, it means we don't have to expose that helper method to the public and creates a single entry point (`include Singleton`).  We could also simplify the `instance` method to have only a single return statement, at the end.  I also added some tests that helped me catch a regression during development.

(ported from https://github.com/ruby/ruby/pull/7890 and thanks to @jeremyevans and @ioquatix for taking a first pass!)

Would this help?