### PR TITLE
ruby version testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 3.2, 3.1, 3.0, 2.7, head ]
+        ruby: [ 3.2, 3.1, 3.0, 2.7, 2.6, 2.5, 2.4, head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 2.7, 2.6, 2.5, 2.4, head ]
+        ruby: [ 3.2, 3.1, 3.0, 2.7, head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
do we want to update the ruby version matrix testing to drop support for older versions and include 3.x ?


https://endoflife.date/ruby