### PR TITLE
simplify retry

### DIFF
--- a/lib/singleton.rb
+++ b/lib/singleton.rb
@@ -121,12 +121,7 @@ module Singleton
     end
 
     def instance # :nodoc:
-      return @singleton__instance__ if @singleton__instance__
-      @singleton__mutex__.synchronize {
-        return @singleton__instance__ if @singleton__instance__
-        @singleton__instance__ = new()
-      }
-      @singleton__instance__
+      @singleton__instance__ || @singleton__mutex__.synchronize { @singleton__instance__ ||= new }
     end
 
     private

--- a/test/test_singleton.rb
+++ b/test/test_singleton.rb
@@ -94,11 +94,32 @@ class TestSingleton < Test::Unit::TestCase
     assert_same a, b
   end
 
+  def test_inheritance_creates_separate_singleton
+    a = SingletonTest.instance
+    b = Class.new(SingletonTest).instance
+
+    assert_not_same a, b
+  end
+
+  def test_inheritance_instantiation
+    klass = Class.new do
+      include Singleton
+
+      public_class_method :new
+    end
+
+    assert Class.new(klass).new
+  end
+
   def test_class_level_cloning_preserves_singleton_behavior
     klass = SingletonTest.clone
 
     a = klass.instance
     b = klass.instance
     assert_same a, b
+  end
+
+  def test_class_level_cloning_creates_separate_singleton
+    assert_not_same SingletonTest.instance, SingletonTest.clone.instance
   end
 end


### PR DESCRIPTION
slimmed down version of https://github.com/ruby/singleton/pull/7 with additional test to catch regression.  as described [here](https://bugs.ruby-lang.org/issues/19711#note-3), Rails expects subclasses of a Singleton to be instantiatable