### PR TITLE
Add TruffleRuby and JRuby to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,20 +6,20 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
-      engine: cruby
       min_version: 2.4
   test:
     needs: ruby-versions
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         exclude:
-          - ruby: 2.4
-            os: macos-latest
-          - ruby: 2.5
-            os: macos-latest
+          - { os: macos-latest, ruby: 2.4 }
+          - { os: macos-latest, ruby: 2.5 }
+          - { os: windows-latest, ruby: truffleruby }
+          - { os: windows-latest, ruby: truffleruby-head }
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This should be helpful to ensure e.g. Ractor-related changes do not break anything on non-CRuby.