### PR TITLE
Fix a `RactorLocalSingleton` lazy mutex race

### DIFF
--- a/lib/singleton.rb
+++ b/lib/singleton.rb
@@ -203,31 +203,13 @@ if defined?(Ractor)
     module RactorLocalSingletonClassMethods # :nodoc:
       include Singleton::SingletonClassMethods
       def instance
-        set_mutex(Thread::Mutex.new) if Ractor.current[mutex_key].nil?
-        return Ractor.current[instance_key] if Ractor.current[instance_key]
-        Ractor.current[mutex_key].synchronize {
-          return Ractor.current[instance_key] if Ractor.current[instance_key]
-          set_instance(new())
-        }
-        Ractor.current[instance_key]
+        Ractor.store_if_absent(instance_key) { new }
       end
 
       private
 
       def instance_key
         :"__RactorLocalSingleton_instance_with_class_id_#{object_id}__"
-      end
-
-      def mutex_key
-        :"__RactorLocalSingleton_mutex_with_class_id_#{object_id}__"
-      end
-
-      def set_instance(val)
-        Ractor.current[instance_key] = val
-      end
-
-      def set_mutex(val)
-        Ractor.current[mutex_key] = val
       end
     end
 


### PR DESCRIPTION
`RactorLocalSingleton` lazily creates the mutex that guards instance creation, but that lazy creation isn't itself guarded. Multiple threads can each see `nil`, create their own mutex and synchronize on different locks.

This switches to using `Ractor.store_if_absent`, which makes the separate mutex and double-checked locking unnecessary. `Ractor.store_if_absent` had not been introduced yet when this code was initially written.

Reproduction:

```ruby
require "singleton"

class Single
  include RactorLocalSingleton

  def initialize
    count = Ractor.current[:instances] || 0
    Ractor.current[:instances] = count.succ
    sleep 0.1
  end

  class << self
    private

    def set_mutex(v)
      sleep 0.01
      super
    end
  end
end

count = Ractor.new do
  Array.new(10) { Thread.new { Single.instance } }.each(&:join)
  Ractor.current[:instances]
end

pp count.value
```

Before patch:
```ruby
10
```

After patch:
```ruby
1
```
